### PR TITLE
[WIP] Initialize some variables

### DIFF
--- a/src/FlowRouting.f90
+++ b/src/FlowRouting.f90
@@ -199,6 +199,8 @@ subroutine find_mult_rec (h,rec0,stack0,water,rec,nrec,wrec,lrec,stack,nx,ny,dx,
 
   nrec=0
   wrec=0.d0
+  lrec=0.d0
+  rec=0.d0
 
   ! loop on all nodes
   do j=bounds_j1,bounds_j2

--- a/src/StreamPowerLaw.f90
+++ b/src/StreamPowerLaw.f90
@@ -48,6 +48,8 @@ subroutine StreamPowerLaw ()
   ! Gauss-Seidel iteration
   nGSStreamPowerLaw=0
 
+  water=0.d0
+  lake_water_volume=0.d0
   lake_sediment=0.d0
   lake_sill=0.d0
   dh=0.d0
@@ -259,7 +261,10 @@ subroutine StreamPowerLaw ()
     ! Gauss-Seidel iteration
     nGSStreamPowerLaw=0
 
+    water=0.d0
+    lake_water_volume=0.d0
     lake_sediment=0.d0
+    lake_sill=0.d0
     dh=0.d0
     hp=h
 


### PR DESCRIPTION
This initializes some variables to 0 which can otherwise be used without being intialized. This in part solves the crashes reported in https://github.com/geodynamics/aspect/issues/6963.

There is one remaining issue in Named_VTK.f90:
In some cases the foldername received seems to have no length. Error message is as follows:
```
At line 1 of file /opt/fastscapelib-fortran/src/Named_VTK.f90
Fortran runtime error: Actual string length is shorter than the declared one for dummy argument 'foldername' (-1/43)
```
So the string length is -1, while it's supposed to be 43. Adding a print statement in ASPECT before the call to name_vtk made the problem go away.

Valgrind also tells me:
```
==3066== Syscall param write(buf) points to uninitialised byte(s)
==3066==    at 0x15B3C93F: __libc_write (write.c:26)
==3066==    by 0x15B3C93F: write (write.c:24)
==3066==    by 0x1DED73E6: ??? (in /usr/lib/x86_64-linux-gnu/libgfortran.so.5.0.0)
==3066==    by 0x1DED749C: ??? (in /usr/lib/x86_64-linux-gnu/libgfortran.so.5.0.0)
==3066==    by 0x1DED6779: ??? (in /usr/lib/x86_64-linux-gnu/libgfortran.so.5.0.0)
==3066==    by 0x1501BE99: fastscape_named_vtk_ (Named_VTK.f90:71)
==3066==    by 0x19AE434: aspect::MeshDeformation::FastScape<2>::execute_fastscape(std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, double const&, unsigned int const&) const (in /opt/build/aspect-debug)
==3066==    by 0x1A5C9D5: aspect::MeshDeformation::FastScape<2>::compute_velocity_constraints_on_boundary(dealii::DoFHandler<2, 2> const&, dealii::AffineConstraints<double>&, std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> > const&) const (in /opt/build/aspect-debug)
==3066==    by 0x1A1FD88: aspect::MeshDeformation::MeshDeformationHandler<2>::make_constraints() (in /opt/build/aspect-debug)
==3066==    by 0x1ABB05B: aspect::MeshDeformation::MeshDeformationHandler<2>::execute() (in /opt/build/aspect-debug)
==3066==    by 0x149C203: aspect::Simulator<2>::solve_timestep() (in /opt/build/aspect-debug)
==3066==    by 0x14B1AC6: aspect::Simulator<2>::run() (in /opt/build/aspect-debug)
==3066==    by 0x1EF29E2: void (anonymous namespace)::run_simulator<2>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, bool, bool, bool, bool) (in /opt/build/aspect-debug)
==3066==  Address 0x2d40341a is 1,914 bytes inside a block of size 131,072 alloc'd
==3066==    at 0x4848899: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==3066==    by 0x1DC7BD88: ??? (in /usr/lib/x86_64-linux-gnu/libgfortran.so.5.0.0)
==3066==    by 0x1DED7154: ??? (in /usr/lib/x86_64-linux-gnu/libgfortran.so.5.0.0)
==3066==    by 0x1DECC77E: ??? (in /usr/lib/x86_64-linux-gnu/libgfortran.so.5.0.0)
==3066==    by 0x1DECD1DD: _gfortran_st_open (in /usr/lib/x86_64-linux-gnu/libgfortran.so.5.0.0)
==3066==    by 0x1501A684: fastscape_named_vtk_ (Named_VTK.f90:59)
==3066==    by 0x19AE434: aspect::MeshDeformation::FastScape<2>::execute_fastscape(std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, std::vector<double, std::allocator<double> >&, double const&, unsigned int const&) const (in /opt/build/aspect-debug)
==3066==    by 0x1A5C9D5: aspect::MeshDeformation::FastScape<2>::compute_velocity_constraints_on_boundary(dealii::DoFHandler<2, 2> const&, dealii::AffineConstraints<double>&, std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> > const&) const (in /opt/build/aspect-debug)
==3066==    by 0x1A1FD88: aspect::MeshDeformation::MeshDeformationHandler<2>::make_constraints() (in /opt/build/aspect-debug)
==3066==    by 0x1ABB05B: aspect::MeshDeformation::MeshDeformationHandler<2>::execute() (in /opt/build/aspect-debug)
==3066==    by 0x149C203: aspect::Simulator<2>::solve_timestep() (in /opt/build/aspect-debug)
==3066==    by 0x14B1AC6: aspect::Simulator<2>::run() (in /opt/build/aspect-debug)
```
Which I think means a longer string has been allocated than actually filled.